### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.6.7组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.relic</groupId>
@@ -21,7 +19,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <tomcat.version>7.0.59</tomcat.version>
-        <jackson.version>2.6.7</jackson.version>
+        <jackson.version>2.9.10.8</jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML Jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.6.7
漏洞编号：CVE-2017-15095
漏洞描述：FasterXML jackson-databind是一个基于JAVA可以将XML和JSON等数据格式与JAVA对象进行转换的库。Jackson可以轻松的将Java对象转换成json对象和xml文档，同样也可以将json、xml转换成Java对象。
FasterXML Jackson-databind 2.8.10之前版本和2.9.1之前版本中存在代码问题漏洞。攻击者可通过向ObjectMapper的readValue方法发送特制的输入利用该漏洞执行代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2017-32627
影响范围：(∞, 2.6.7.1)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.relic:transfer_helper@1.0-SNAPSHOT->com.fasterxml.jackson.core:jackson-databind@2.6.7
```
另外我运行这个项目时，IDE的安全插件提示还有130个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p8f94b